### PR TITLE
scale the Deskbar icon

### DIFF
--- a/Source/NetPulse.cpp
+++ b/Source/NetPulse.cpp
@@ -44,9 +44,9 @@ NetPulse::ReadyToRun()
 }
 
 
-extern "C" _EXPORT BView *instantiate_deskbar_item()
+extern "C" _EXPORT BView *instantiate_deskbar_item(float /*maxWidth*/, float maxHeight)
 {
-	return new NetPulseView("NetPulseView");
+	return new NetPulseView(maxHeight);
 }
 
 

--- a/Source/NetPulseView.cpp
+++ b/Source/NetPulseView.cpp
@@ -30,10 +30,10 @@ static const bigtime_t kDefaultUpdateInterval = 250000LL;
 static const float kDefaultDecayRate = 0.90;
 
 
-NetPulseView::NetPulseView(const char* name)
+NetPulseView::NetPulseView(float maxHeight)
 	:
-	BView(BRect(0, 0, C_MODEM_ICON_WIDTH - 1, C_MODEM_ICON_HEIGHT - 1),
-		name, B_FOLLOW_ALL_SIDES, B_WILL_DRAW),
+	BView(BRect(0, 0, maxHeight - 1, maxHeight - 1),
+		"NetPulseView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW),
 	fMessenger(NULL),
 	fMessageRunner(NULL),
 	fModemDownBitmap(NULL),
@@ -282,14 +282,14 @@ NetPulseView::Draw(BRect updateRect)
 	if (fEnable) {
 		SetDrawingMode(B_OP_OVER);
 		if (fModemUpBitmap != NULL)
-			DrawBitmapAsync(fModemUpBitmap, BPoint(0, 0));
+			DrawBitmapAsync(fModemUpBitmap, fModemUpBitmap->Bounds(), Bounds());
 	} else {
 		SetHighColor(ViewColor());
 		FillRect(updateRect);
 
 		SetDrawingMode(B_OP_OVER);
 		if (fModemDownBitmap != NULL)
-			DrawBitmapAsync(fModemDownBitmap, BPoint(0, 0));
+			DrawBitmapAsync(fModemDownBitmap, fModemDownBitmap->Bounds(), Bounds());
 	}
 }
 

--- a/Source/NetPulseView.h
+++ b/Source/NetPulseView.h
@@ -16,7 +16,7 @@ const int32 kColorLevels			= 32;
 
 class _EXPORT NetPulseView : public BView {
 public:
-								NetPulseView(const char* name);
+								NetPulseView(float maxHeight);
 								NetPulseView(BMessage* message);
 	virtual						~NetPulseView();
 


### PR DESCRIPTION
Use basic bitmap scaling to make the Deskbar icon usable with high resolution displays.